### PR TITLE
#3345 - move attribute comparisons into their own method on the model

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -463,8 +463,8 @@
       // For each `set` attribute, update or delete the current value.
       for (attr in attrs) {
         val = attrs[attr];
-        if (!_.isEqual(current[attr], val)) changes.push(attr);
-        if (!_.isEqual(prev[attr], val)) {
+        if (!this.attributesAreEqual(current[attr], val)) changes.push(attr);
+        if (!this.attributesAreEqual(prev[attr], val)) {
           this.changed[attr] = val;
         } else {
           delete this.changed[attr];
@@ -493,6 +493,12 @@
       this._pending = false;
       this._changing = false;
       return this;
+    },
+    
+    // Compare two attributes, return true if they are found to be equal.
+    // (3345)
+    attributesAreEqual: function( attrA, attrB ) {
+        return _.isEqual( attrA, attrB );
     },
 
     // Remove an attribute from the model, firing `"change"`. `unset` is a noop
@@ -526,7 +532,7 @@
       var val, changed = false;
       var old = this._changing ? this._previousAttributes : this.attributes;
       for (var attr in diff) {
-        if (_.isEqual(old[attr], (val = diff[attr]))) continue;
+        if (this.attributesAreEqual(old[attr], (val = diff[attr]))) continue;
         (changed || (changed = {}))[attr] = val;
       }
       return changed;

--- a/test/index.html
+++ b/test/index.html
@@ -6,9 +6,12 @@
   <link rel="stylesheet" href="vendor/qunit.css" type="text/css" media="screen">
 </head>
 <body>
-  <script src="setup/dom-setup.js"></script>
+  <!-- <script src="setup/dom-setup.js"></script> -->
   <script src="vendor/json2.js"></script>
   <script src="vendor/jquery.js"></script>
+  
+    <script src="setup/dom-setup.js"></script>
+    
   <script src="vendor/qunit.js"></script>
   <script src="vendor/underscore.js"></script>
   <script src="../backbone.js"></script>

--- a/test/model.js
+++ b/test/model.js
@@ -1277,5 +1277,17 @@
     });
     model.set({a: true});
   });
+    
+  test("3345 - attributesAreEqual", 3, function() {
+      var model = new Backbone.Model(),
+        a = 1,
+        b = 2,
+        c = 1,
+        d = {};
+      
+      ok( !model.attributesAreEqual( a, b ) );
+      ok( model.attributesAreEqual( a, c ) );
+      ok( model.attributesAreEqual( d, d ) );
+  });
 
 })();


### PR DESCRIPTION
This should allow models to provide custom logic to compare attributes. For a set, each attribute will still be compared to every other attribute between the two models. I'm not going to try to change that behavior. This should be enough wiggle room to allow for more powerful comparisons.

I don't know about naming conventions but `attributesAreEqual` does not appear in any Backbone projects on Github. I'm not wedded to the name. 